### PR TITLE
eliminate progress bar dependency

### DIFF
--- a/moveFiles.py
+++ b/moveFiles.py
@@ -1,11 +1,10 @@
 import getpass
-import progressbar
 import os
 from os.path import join as opj, isdir, exists
 from shutil import move, copy, copytree
 from subprocess import check_output
 import argparse
-from utils import nojobsrunning, Njobs, cpr
+from utils import nojobsrunning, Njobs, cpr, updateprogress
 
 IsMain = __name__ == '__main__'
 
@@ -147,9 +146,7 @@ def moveFiles(signal_name=args.signal_name, run_sys=args.run_sys, store_sys=args
         return endstep()
     
     print len(subdirlist), 'directories to {}...'.format(thingstr)
-    dirbar = progressbar.ProgressBar(maxval=len(subdirlist),
-                                     widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage() ]
-                                     )
+    dirbar = updateprogress(len(subdirlist))
     dirbar.start()
     
     for i, subdir in enumerate(subdirlist):

--- a/submit_to_condor.py
+++ b/submit_to_condor.py
@@ -3,7 +3,6 @@ from subprocess import call
 import os
 from os.path import join as opj, abspath
 from time import sleep
-import progressbar
 from imp import load_source
 from utils import makelohilist, incfilename
 from moveFiles import moveFiles, runMoveFilesContinuously, parser  # some args overridden--see below

--- a/utils.py
+++ b/utils.py
@@ -64,3 +64,8 @@ def incfilename(filename, i_start=0, i=None):
             return newname
     else:
         return filename
+
+
+def makepercent(num, tot):
+    'returns an integer representing num/tot as a percentage'
+    return int(float(num) * 100 / float(tot))

--- a/utils.py
+++ b/utils.py
@@ -69,3 +69,45 @@ def incfilename(filename, i_start=0, i=None):
 def makepercent(num, tot):
     'returns an integer representing num/tot as a percentage'
     return int(float(num) * 100 / float(tot))
+
+    
+class updateprogress(object):
+    """docstring for updateprogress"""
+    
+    def __init__(self, maxval):
+        super(updateprogress, self).__init__()
+        self.maxval = maxval
+        import imp
+        try:
+            imp.find_module('progressbar')
+            self.useprogressbar = True
+        except ImportError:
+            self.useprogressbar = False
+    
+    def _printupdate(self, addstring=''):
+        print 'on {0} out of {1} ({2}%) {3}'.format(self.counter, self.maxval, makepercent(self.counter, self.maxval), addstring)
+
+    def start(self):
+        self.counter = 0
+        if self.useprogressbar:
+            import progressbar
+            self.progbar = progressbar.ProgressBar(maxval=self.maxval,
+                                                   widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage() ]
+                                                   )
+            self.progbar.start()
+        else:
+            print 'tracking progress'
+            self._printupdate()
+    
+    def update(self, i):
+        self.counter = i
+        if self.useprogressbar:
+            self.progbar.update(i)
+        else:
+            self._printupdate()
+    
+    def finish(self):
+        if self.useprogressbar:
+            self.progbar.finish()
+        else:
+            self._printupdate('(finished)')


### PR DESCRIPTION
Introduces a new class `updateprogress`. This class functions almost identically to progressbar in terms of interface, but only uses the progressbar package if it is available, enabling users to enjoy the beauty of progressbar if they want to, but without requiring them to install it.